### PR TITLE
Firstutils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 .ropeproject
 *.out
 pynt.egg-info
+.idea

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A collection of common pynt tasks
 * Ivan Ven Osdel
 
 
-If you want to make changes the repo is at https://github.com/rags/pynt-contrib. You will need [pytest](http://www.pytest.org) to run the tests
+If you want to make changes the repo is at https://github.com/rags/pynt-contrib. You will need [pytest](http://www.pytest.org) and mock to run the tests
 
 ```bash
 $ ./b t

--- a/pynt/contrib/__init__.py
+++ b/pynt/contrib/__init__.py
@@ -1,3 +1,49 @@
+import contextlib
+import os
+from subprocess import check_call, CalledProcessError
+import sys
+
 __version__ = "0.1.0"
 __license__ = "MIT License"
 __contact__ = "http://rags.github.com/pynt-contrib/"
+
+
+def _print(value):
+    print(value)
+
+
+@contextlib.contextmanager
+def safe_cd(path):
+    """
+    Changes to a directory, yields, and changes back.
+    Additionally any error will also change the directory back.
+
+    Usage:
+    >>> with safe_cd('some/repo'):
+    ...     call('git status')
+    """
+    starting_directory = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(starting_directory)
+
+
+def execute(script, *args):
+    """
+    Executes a command through the shell. Spaces should breakup the args.
+
+    Usage:
+    >>> execute('grep', 'TODO', '*')
+    """
+
+    popen_args = [script] + list(args)
+    try:
+        return check_call(popen_args, shell=False)
+    except CalledProcessError as ex:
+        _print(ex)
+        sys.exit(ex.returncode)
+    except Exception as ex:
+        _print('Error: {} with script: {} and args {}'.format(ex, script, args))
+        sys.exit(1)

--- a/pynt/contrib/tests/test_execute.py
+++ b/pynt/contrib/tests/test_execute.py
@@ -1,0 +1,37 @@
+from subprocess import CalledProcessError
+import unittest
+import mock
+
+from ...contrib import execute
+
+__version__ = "0.1.0"
+__license__ = "MIT License"
+__contact__ = "http://rags.github.com/pynt-contrib/"
+
+
+class TestExecute(unittest.TestCase):
+
+    @mock.patch('pynt.contrib.check_call')
+    @mock.patch('pynt.contrib._print')
+    @mock.patch('pynt.contrib.sys.exit')
+    def test_successful_command(self, mock_exit, mock_print_, mock_check_call):
+        """A successful command should not exit"""
+        execute('python', '-V')
+
+        self.assertFalse(mock_exit.called)
+        self.assertFalse(mock_print_.called)
+        self.assertTrue(mock_check_call.called)
+
+    @mock.patch('pynt.contrib.check_call')
+    @mock.patch('pynt.contrib._print')
+    @mock.patch('pynt.contrib.sys.exit')
+    def test_bad_command(self, mock_exit, mock_print_, mock_check_call):
+        """A bad command should exit with the error code"""
+        command = ['notatall', 'athing']
+        mock_check_call.side_effect = CalledProcessError(1, command)
+
+        execute(*command)
+
+        self.assertTrue(mock_exit.called)
+        self.assertTrue(mock_print_.called)
+        self.assertTrue(mock_check_call.called)

--- a/pynt/contrib/tests/test_safecd.py
+++ b/pynt/contrib/tests/test_safecd.py
@@ -1,0 +1,33 @@
+import os
+import tempfile
+import unittest
+
+from ...contrib import safe_cd
+
+__version__ = "0.1.0"
+__license__ = "MIT License"
+__contact__ = "http://rags.github.com/pynt-contrib/"
+
+
+class TestSafeCd(unittest.TestCase):
+
+    def setUp(self):
+        self.cwd = os.getcwd()
+        self.temp_dir = tempfile.mkdtemp('pyntcontrib')
+
+    def test_change_yield_revert(self):
+        """Safe cd should change directory, yield and revert back"""
+        with safe_cd(self.temp_dir):
+            os.path.exists(self.temp_dir)
+
+        self.assertEqual(os.getcwd(), self.cwd, "Working directory was not restored.")
+
+    def test_change_error_revert(self):
+        """Should restore directory after an exception during yield"""
+        try:
+            with safe_cd(self.temp_dir):
+                raise ValueError
+        except ValueError:
+            pass
+
+        self.assertEqual(os.getcwd(), self.cwd, "Working directory was not restored.")


### PR DESCRIPTION
Here it is. A couple of caveats:
1. Please excuse the .idea ignore it's for PyCharm users. 
2. I need mock in order to be able to run the execute tests for both 2.7 and 3.x. I find that the easiest is just to add it as a test dependency so that the tests simply `import mock`. I didn't see a test requirements list so I just updated the README.md.

A few things I noticed but did not address:
1. It looks like the build status is still pointing to pynt and not pynt-contrib.
2. It seems like the latest version of pytest just installs with py.test-2.7 and py.test-3.4. `pynt test` seems to be looking for 3.3.
